### PR TITLE
Update ownership.json to include a custom petclinic using Spring 2.7

### DIFF
--- a/src/main/resources/ownership.json
+++ b/src/main/resources/ownership.json
@@ -356,6 +356,11 @@
         "origin": "github.com",
         "path": "spring-projects/*",
         "branch": "*"
+      },
+      {
+        "origin": "github.com",
+        "path": "moderneinc/spring-petclinic",
+        "branch": "2.0"
       }
     ]
   }


### PR DESCRIPTION
Already published and also added here: https://github.com/moderneinc/jenkins-ingest/pull/95

Correct me if I am wrong, but this will allow everybody, with their accounts to use an existing and visible Spring application using Spring 2.7. Otherwise, only team members can see other repositories.