### PR TITLE
Fix issue with removed shaded dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,8 +76,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("io.micrometer:micrometer-core:latest.release")
 
-    implementation("com.graphql-java:graphql-java:18+")
-    implementation("com.graphql-java:graphql-java-extended-scalars:18+")
+    implementation("com.graphql-java:graphql-java-extended-scalars:19+")
 
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 


### PR DESCRIPTION
The latest 19.x version (19.7) no longer has `graphql.com.google.common.collect` shaded and this is breaking because `com.graphql-java:graphql-java-extended-scalars` is kept at 19.1 which relies on it.

Since DGS framework already includes graphql-java (default at 19.5) after any CVE but before the removal of the shaded dependency, this solves the issue.