### PR TITLE
The "Spring Boot 3.2" card doesn't quite make sense, its title cites …

### DIFF
--- a/src/main/resources/devcenter.json
+++ b/src/main/resources/devcenter.json
@@ -167,7 +167,7 @@
     "devCenter": {
       "upgradesAndMigrations": [
         {
-          "title": "Spring boot 3.2",
+          "title": "Spring boot 3.2.5",
           "measures": [
             {
               "name": "Major",
@@ -176,15 +176,15 @@
                 "options": [
                   {
                     "name": "groupIdPattern",
-                    "value": "org.springframework.boot"
+                    "value": "org.springframework"
                   },
                   {
                     "name": "artifactIdPattern",
-                    "value": "spring-boot"
+                    "value": "spring-core"
                   },
                   {
                     "name": "version",
-                    "value": "1-2"
+                    "value": "[,5)"
                   }
                 ]
               }
@@ -196,15 +196,15 @@
                 "options": [
                   {
                     "name": "groupIdPattern",
-                    "value": "org.springframework.boot"
+                    "value": "org.springframework"
                   },
                   {
                     "name": "artifactIdPattern",
-                    "value": "spring-boot"
+                    "value": "spring-core"
                   },
                   {
                     "name": "version",
-                    "value": "3-3.1"
+                    "value": "[5,6.0)"
                   }
                 ]
               }
@@ -216,15 +216,15 @@
                 "options": [
                   {
                     "name": "groupIdPattern",
-                    "value": "org.springframework.boot"
+                    "value": "org.springframework"
                   },
                   {
                     "name": "artifactIdPattern",
-                    "value": "spring-boot"
+                    "value": "spring-core"
                   },
                   {
                     "name": "version",
-                    "value": "3.2-3.2.2"
+                    "value": "6.1.1-6.1.5"
                   }
                 ]
               }


### PR DESCRIPTION
…a minor version target but the chart includes a "patch" section. Incrementing a patch versions will never result in getting to a new minor version. There isn't a conversion factor like 10 patch bumps -> 1 minor bump. A patch version bump and a minor version bump are qualitatively different.

To make this make sense I am updating the title of the card to cite the patch version target.

Additionally, I am improving the display to determine the spring boot version based on the version of spring-core, rather than the version of spring-boot. This is because libraries used by spring boot applications might benefit from the upgrade recipe without themselves taking a dependency on spring-boot itself. These currently fall through the cracks, showing as "complete" even if they are based on a very old version of spring and do need to be upgraded.