### PR TITLE
feat: Allow multiple SCM origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ There is repetition in organizational hierarchy in this format. The reference im
 If you have multiple organizations with the same display name, you can map id to display name in an `id-mapping.txt`. A simple reference
 file is included in this repository.
 
+### Mapping repositories
+
+When dealing with public SaaS SCMs it's easy to map a cloneUrl to a reporitory origin and path, but when self hosting figuring out where the origin ends and the path starts can be tricky.
+To achieve this mapping you need an implementation of [RepositoryMapper.java](src/main/java/io/moderne/organizations/RepositoryMapper.java) interface and inject a Spring bean of that type.
+
+For your convenience we have created a simple version which you can supply origins (host + context-path) and the mapper will use that to split a clone url into the origin and path.
+See [Application.java](src/main/java/io/moderne/organizations/Application.java) in the example code.
+
+Example: 
+If you have a repository at `cloneUrl=https://bitbucket.example.com/stash/scm/openrewrite/rewrite.git` and supply `OriginBasedRepositoryMapper` with `bitbucket.example.com/stash/scm` it will create a repository:
+
+```
+{
+    "origin": "bitbucket.example.com/stash/scm",
+    "path": "openrewrite/rewrite",
+    "branch": "main"
+}
+```
+
 ### Commit options
 The `commitOptions` field on the `Organization` type is a list of strings that represent the commit options that are
 available to developers in that organization. These are the options that are presented to developers when they create a

--- a/src/main/java/io/moderne/organizations/Application.java
+++ b/src/main/java/io/moderne/organizations/Application.java
@@ -2,11 +2,22 @@ package io.moderne.organizations;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class Application {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    public RepositoryMapper repositoryMapper() {
+        return new RepositoryMapper.OriginBasedRepositoryMapper(
+                "github.com",
+                "bitbucket.org",
+                "gitlab.com",
+                "bitbucket.example.com/stash/scm"
+        );
     }
 }

--- a/src/main/java/io/moderne/organizations/RepositoryMapper.java
+++ b/src/main/java/io/moderne/organizations/RepositoryMapper.java
@@ -1,0 +1,51 @@
+package io.moderne.organizations;
+
+import io.moderne.organizations.types.RepositoryInput;
+import org.openrewrite.internal.lang.Nullable;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public interface RepositoryMapper {
+    @Nullable
+    RepositoryInput determineRepository(String cloneUrl, String branch);
+
+    class OriginBasedRepositoryMapper implements RepositoryMapper {
+
+        Map<String, Pattern> urlPatterns;
+
+        OriginBasedRepositoryMapper(String... origins) {
+            urlPatterns = new LinkedHashMap<>();
+            for (String origin : origins) {
+                Pattern pattern = Pattern.compile(origin + "/(.*)");
+                urlPatterns.put(origin, pattern);
+            }
+        }
+
+        @Nullable
+        @Override
+        public RepositoryInput determineRepository(String cloneUrl, String branch) {
+            for (Map.Entry<String, Pattern> entry : urlPatterns.entrySet()) {
+                String origin = entry.getKey();
+                Matcher matcher = entry.getValue().matcher(cloneUrl);
+                if (matcher.find()) {
+                    String path = cleanPath(matcher.group(1));
+                    return new RepositoryInput(path, origin, branch);
+                }
+            }
+            return null;
+        }
+
+        private static String cleanPath(String path) {
+            if (path.startsWith("/")) {
+                path = path.substring(1);
+            }
+            if (path.endsWith(".git")) {
+                path = path.substring(0, path.length() - 4);
+            }
+            return path;
+        }
+    }
+}

--- a/src/main/resources/repos.csv
+++ b/src/main/resources/repos.csv
@@ -50,3 +50,4 @@ https://github.com/Netflix/iep,main,Netflix,Open source,ALL
 https://github.com/Netflix/mantis-rxcontrol,master,Netflix,Open source,ALL
 https://github.com/Netflix/vmaf,master,Netflix,Open source,ALL
 https://github.com/Netflix/x-element,main,Netflix,Open source,ALL
+https://bitbucket.example.com/stash/scm/openrewrite/rewrite.git,main,OpenRewrite,Open source,ALL

--- a/src/test/java/io/moderne/organizations/OrganizationDataFetcherTest.java
+++ b/src/test/java/io/moderne/organizations/OrganizationDataFetcherTest.java
@@ -1,14 +1,15 @@
 package io.moderne.organizations;
 
-import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.context.SpringBootTest;
 import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = {DgsAutoConfiguration.class, CustomScalarsConfiguration.class, OrganizationDataFetcher.class, OrganizationStructureService.class})
+@AutoConfigureObservability
+@SpringBootTest
 public class OrganizationDataFetcherTest {
 
     @Autowired


### PR DESCRIPTION
Add `RepositoryMapper` with a default implementation to allow mapping between multiple SCM origins.
