### PR TITLE
feat: Add configurable name for DevCenter security recipe

### DIFF
--- a/src/main/java/io/moderne/organizations/DgsConstants.java
+++ b/src/main/java/io/moderne/organizations/DgsConstants.java
@@ -130,6 +130,8 @@ public class DgsConstants {
   public static class DEVCENTERRECIPE {
     public static final String TYPE_NAME = "DevCenterRecipe";
 
+    public static final String Name = "name";
+
     public static final String RecipeId = "recipeId";
 
     public static final String Options = "options";

--- a/src/main/java/io/moderne/organizations/types/DevCenterRecipe.java
+++ b/src/main/java/io/moderne/organizations/types/DevCenterRecipe.java
@@ -6,6 +6,11 @@ import java.lang.String;
 import java.util.List;
 
 public class DevCenterRecipe {
+  /**
+   * Optional name used for displaying on the DevCenter. Defaults to the recipe display name.
+   */
+  private String name;
+
   private String recipeId;
 
   private List<Option> options;
@@ -13,9 +18,21 @@ public class DevCenterRecipe {
   public DevCenterRecipe() {
   }
 
-  public DevCenterRecipe(String recipeId, List<Option> options) {
+  public DevCenterRecipe(String name, String recipeId, List<Option> options) {
+    this.name = name;
     this.recipeId = recipeId;
     this.options = options;
+  }
+
+  /**
+   * Optional name used for displaying on the DevCenter. Defaults to the recipe display name.
+   */
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
   }
 
   public String getRecipeId() {
@@ -36,7 +53,7 @@ public class DevCenterRecipe {
 
   @Override
   public String toString() {
-    return "DevCenterRecipe{" + "recipeId='" + recipeId + "'," +"options='" + options + "'" +"}";
+    return "DevCenterRecipe{" + "name='" + name + "'," +"recipeId='" + recipeId + "'," +"options='" + options + "'" +"}";
   }
 
   @Override
@@ -44,13 +61,14 @@ public class DevCenterRecipe {
     if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DevCenterRecipe that = (DevCenterRecipe) o;
-        return java.util.Objects.equals(recipeId, that.recipeId) &&
+        return java.util.Objects.equals(name, that.name) &&
+                            java.util.Objects.equals(recipeId, that.recipeId) &&
                             java.util.Objects.equals(options, that.options);
   }
 
   @Override
   public int hashCode() {
-    return java.util.Objects.hash(recipeId, options);
+    return java.util.Objects.hash(name, recipeId, options);
   }
 
   public static io.moderne.organizations.types.DevCenterRecipe.Builder newBuilder() {
@@ -58,15 +76,29 @@ public class DevCenterRecipe {
   }
 
   public static class Builder {
+    /**
+     * Optional name used for displaying on the DevCenter. Defaults to the recipe display name.
+     */
+    private String name;
+
     private String recipeId;
 
     private List<Option> options;
 
     public DevCenterRecipe build() {
                   io.moderne.organizations.types.DevCenterRecipe result = new io.moderne.organizations.types.DevCenterRecipe();
-                      result.recipeId = this.recipeId;
+                      result.name = this.name;
+          result.recipeId = this.recipeId;
           result.options = this.options;
                       return result;
+    }
+
+    /**
+     * Optional name used for displaying on the DevCenter. Defaults to the recipe display name.
+     */
+    public io.moderne.organizations.types.DevCenterRecipe.Builder name(String name) {
+      this.name = name;
+      return this;
     }
 
     public io.moderne.organizations.types.DevCenterRecipe.Builder recipeId(String recipeId) {

--- a/src/main/resources/schema/moderne-organizations.graphqls
+++ b/src/main/resources/schema/moderne-organizations.graphqls
@@ -106,6 +106,10 @@ type DevCenterRecipeCard {
 }
 
 type DevCenterRecipe {
+    """
+    Optional name used for displaying on the DevCenter. Defaults to the recipe display name.
+    """
+    name: String
     recipeId: String!
     options: [Option!]!
 }


### PR DESCRIPTION
Can be used in cases where the recipe display name is not sufficient. For example when the same recipe is used with different options.