### PR TITLE
feat: Use the new GitRemote logic - Support multiple URIs per SCM server

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,16 @@ file is included in this repository.
 
 Edit [application.yaml](src/main/resources/application.yaml) and list all the base uris for any private SCM providers used in the repos.csv.
 
-You will need to provide the base uri, type and any alternative uri that can be used to access the same SCM server.
+You will need to provide the base URL, type and any alternative URL that can be used to access the same SCM server.
 
 Example:
 ```yaml
 moderne:
   scm:
     repositories:
-      - baseUri: https://bitbucket.example.com/stash
+      - baseUrl: https://bitbucket.example.com/stash
         type: Bitbucket
-        alternativeUris:
+        alternativeUrls:
           - http://bitbucket.example.com:8080/stash
           - ssh://bitbucket.example.com/stash
           - ssh://bitbucket.example.com:7999/stash
@@ -78,7 +78,7 @@ moderne:
 
 Make sure to provide the service type. The following (self-hosted) SCM providers are supported: `[GitHub,GitLab,Bitbucket]`.
 
-We use this configuration to split the clone uri into an origin and path.
+We use this configuration to split the clone URL into an origin and path.
 
 Note that for an on-premise Bitbucket (DC/server) we should not have the `scm/` path segment in the origin or the path. This will automatically be stripped off if you configure this as explained above.
 
@@ -95,7 +95,7 @@ If you have a repository at `cloneUrl=https://bitbucket.example.com/stash/scm/op
 
 you can set `moderne.scm.allow-missing-scm-origins` in [application.yaml](src/main/resources/application.yaml) to true if you want to strictly check on startup that all origins in repos.csv are present.
 
-Note: for backwards compatibility we read the `origin` if the `baseUri` is not supplied and apply the default `https://` protocol to it. It is highly recommended to update the configuration to contain full URIs.
+Note: for backwards compatibility we read the `origin` if the `baseUrl` is not supplied and apply the default `https://` protocol to it. It is highly recommended to update the configuration to contain full URIs.
 
 ### Commit options
 The `commitOptions` field on the `Organization` type is a list of strings that represent the commit options that are

--- a/README.md
+++ b/README.md
@@ -59,13 +59,31 @@ file is included in this repository.
 
 ### Mapping repositories
 
-Edit [application.yaml](src/main/resources/application.yaml) to list all the origins (host + context path) for the SCM providers listed in the repos.csv, and provide a type: `[GITHUB,GITLAB,BITBUCKET_CLOUD,BITBUCKET,AZURE_DEVOPS]`.
-This will be used to split the clone url into an origin and path.
+Edit [application.yaml](src/main/resources/application.yaml) and list all the base uris for any private SCM providers used in the repos.csv.
 
-Note that for an on-premise Bitbucket (server) we should not have the `scm/` path segment in the origin or the path. This will automatically be stripped off if you configure this as explained above.
+You will need to provide the base uri, type and any alternative uri that can be used to access the same SCM server.
+
+Example:
+```yaml
+moderne:
+  scm:
+    repositories:
+      - baseUri: https://bitbucket.example.com/stash
+        type: Bitbucket
+        alternativeUris:
+          - http://bitbucket.example.com:8080/stash
+          - ssh://bitbucket.example.com/stash
+          - ssh://bitbucket.example.com:7999/stash
+```
+
+Make sure to provide the service type. The following (self-hosted) SCM providers are supported: `[GitHub,GitLab,Bitbucket]`.
+
+We use this configuration to split the clone uri into an origin and path.
+
+Note that for an on-premise Bitbucket (DC/server) we should not have the `scm/` path segment in the origin or the path. This will automatically be stripped off if you configure this as explained above.
 
 Example: 
-If you have a repository at `cloneUrl=https://bitbucket.example.com/stash/scm/openrewrite/rewrite.git` and supply `bitbucket.example.com/stash` it will create a repository:
+If you have a repository at `cloneUrl=https://bitbucket.example.com/stash/scm/openrewrite/rewrite.git` and supply `https://bitbucket.example.com/stash` as the origin it will create a repository:
 
 ```
 {
@@ -76,6 +94,8 @@ If you have a repository at `cloneUrl=https://bitbucket.example.com/stash/scm/op
 ```
 
 you can set `moderne.scm.allow-missing-scm-origins` in [application.yaml](src/main/resources/application.yaml) to true if you want to strictly check on startup that all origins in repos.csv are present.
+
+Note: for backwards compatibility we read the `origin` if the `baseUri` is not supplied and apply the default `https://` protocol to it. It is highly recommended to update the configuration to contain full URIs.
 
 ### Commit options
 The `commitOptions` field on the `Organization` type is a list of strings that represent the commit options that are

--- a/src/main/java/io/moderne/organizations/Application.java
+++ b/src/main/java/io/moderne/organizations/Application.java
@@ -17,7 +17,7 @@ public class Application {
     @Bean
     GitRemote.Parser gitRemoteParser(ScmConfiguration scmConfiguration) {
         GitRemote.Parser gitRemoteParser = new GitRemote.Parser();
-        scmConfiguration.getRepositories().forEach(scmRepository -> gitRemoteParser.registerRemote(scmRepository.getGitRemoteService(), scmRepository.getBaseUrl(), scmRepository.getAlternativeUrls()));
+        scmConfiguration.getRepositories().forEach(scmRepository -> gitRemoteParser.registerRemote(scmRepository.getType(), scmRepository.getBaseUrl(), scmRepository.getAlternativeUrls()));
         return gitRemoteParser;
     }
 

--- a/src/main/java/io/moderne/organizations/Application.java
+++ b/src/main/java/io/moderne/organizations/Application.java
@@ -1,8 +1,10 @@
 package io.moderne.organizations;
 
+import org.openrewrite.GitRemote;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 
 @EnableConfigurationProperties(ScmConfiguration.class)
 @SpringBootApplication
@@ -10,6 +12,13 @@ public class Application {
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    GitRemote.Parser gitRemoteParser(ScmConfiguration scmConfiguration) {
+        GitRemote.Parser gitRemoteParser = new GitRemote.Parser();
+        scmConfiguration.getRepositories().forEach(scmRepository -> gitRemoteParser.registerRemote(scmRepository.getType(), scmRepository.getBaseUri(), scmRepository.getAlternativeUris()));
+        return gitRemoteParser;
     }
 
 }

--- a/src/main/java/io/moderne/organizations/Application.java
+++ b/src/main/java/io/moderne/organizations/Application.java
@@ -18,7 +18,12 @@ public class Application {
     GitRemote.Parser gitRemoteParser(ModerneConfiguration moderneConfiguration) {
         ScmConfiguration scmConfiguration = moderneConfiguration.getScm();
         GitRemote.Parser gitRemoteParser = new GitRemote.Parser();
-        scmConfiguration.getRepositories().forEach(scmRepository -> gitRemoteParser.registerRemote(scmRepository.getType(), scmRepository.getBaseUrl(), scmRepository.getAlternativeUrls()));
+        scmConfiguration.getRepositories()
+                .forEach(scmRepository -> gitRemoteParser.registerRemote(
+                        scmRepository.getType(),
+                        scmRepository.getBaseUrl(),
+                        scmRepository.getAlternativeUrls()
+                ));
         return gitRemoteParser;
     }
 

--- a/src/main/java/io/moderne/organizations/Application.java
+++ b/src/main/java/io/moderne/organizations/Application.java
@@ -15,7 +15,8 @@ public class Application {
     }
 
     @Bean
-    GitRemote.Parser gitRemoteParser(ScmConfiguration scmConfiguration) {
+    GitRemote.Parser gitRemoteParser(ModerneConfiguration moderneConfiguration) {
+        ScmConfiguration scmConfiguration = moderneConfiguration.getScm();
         GitRemote.Parser gitRemoteParser = new GitRemote.Parser();
         scmConfiguration.getRepositories().forEach(scmRepository -> gitRemoteParser.registerRemote(scmRepository.getType(), scmRepository.getBaseUrl(), scmRepository.getAlternativeUrls()));
         return gitRemoteParser;

--- a/src/main/java/io/moderne/organizations/Application.java
+++ b/src/main/java/io/moderne/organizations/Application.java
@@ -17,7 +17,7 @@ public class Application {
     @Bean
     GitRemote.Parser gitRemoteParser(ScmConfiguration scmConfiguration) {
         GitRemote.Parser gitRemoteParser = new GitRemote.Parser();
-        scmConfiguration.getRepositories().forEach(scmRepository -> gitRemoteParser.registerRemote(scmRepository.getType(), scmRepository.getBaseUrl(), scmRepository.getAlternativeUrls()));
+        scmConfiguration.getRepositories().forEach(scmRepository -> gitRemoteParser.registerRemote(scmRepository.getGitRemoteService(), scmRepository.getBaseUrl(), scmRepository.getAlternativeUrls()));
         return gitRemoteParser;
     }
 

--- a/src/main/java/io/moderne/organizations/Application.java
+++ b/src/main/java/io/moderne/organizations/Application.java
@@ -17,7 +17,7 @@ public class Application {
     @Bean
     GitRemote.Parser gitRemoteParser(ScmConfiguration scmConfiguration) {
         GitRemote.Parser gitRemoteParser = new GitRemote.Parser();
-        scmConfiguration.getRepositories().forEach(scmRepository -> gitRemoteParser.registerRemote(scmRepository.getType(), scmRepository.getBaseUri(), scmRepository.getAlternativeUris()));
+        scmConfiguration.getRepositories().forEach(scmRepository -> gitRemoteParser.registerRemote(scmRepository.getType(), scmRepository.getBaseUrl(), scmRepository.getAlternativeUrls()));
         return gitRemoteParser;
     }
 

--- a/src/main/java/io/moderne/organizations/OrganizationStructureService.java
+++ b/src/main/java/io/moderne/organizations/OrganizationStructureService.java
@@ -136,6 +136,6 @@ public class OrganizationStructureService {
 
     RepositoryInput determineRepository(String cloneUrl, String branch) {
         GitRemote gitRemote = gitRemoteParser.parse(cloneUrl);
-        return new RepositoryInput(gitRemote.getOrigin(), gitRemote.getPath(), branch);
+        return new RepositoryInput(gitRemote.getPath(), gitRemote.getOrigin(), branch);
     }
 }

--- a/src/main/java/io/moderne/organizations/ScmConfiguration.java
+++ b/src/main/java/io/moderne/organizations/ScmConfiguration.java
@@ -31,6 +31,9 @@ class ScmConfiguration {
     }
 
     static class ScmRepository {
+        /**
+         * Use baseUrl instead
+         */
         @Deprecated
         @Nullable
         private String origin;
@@ -38,35 +41,35 @@ class ScmConfiguration {
         private GitRemote.Service type;
 
         @Nullable
-        private URI baseUri;
+        private URI baseUrl;
 
         @Nullable
-        private List<URI> alternativeUris;
+        private List<URI> alternativeUrls;
 
-        public List<URI> getAlternativeUris() {
-            if (baseUri != null) {
-                return Objects.requireNonNullElse(alternativeUris, Collections.emptyList());
+        public List<URI> getAlternativeUrls() {
+            if (baseUrl != null) {
+                return Objects.requireNonNullElse(alternativeUrls, Collections.emptyList());
             }
             {
                 // backwards compatibility
-                if (alternativeUris != null) {
-                    throw new IllegalStateException("Using alternativeUris without baseUri is not supported");
+                if (alternativeUrls != null) {
+                    throw new IllegalStateException("Using alternativeUrls without baseUrl is not supported");
                 }
                 if (originHasProtocol()) {
                     return Collections.emptyList();
                 }
-                return Collections.singletonList(URI.create("ssh://" + origin));
+                return List.of(URI.create("ssh://" + origin));
             }
         }
 
-        public URI getBaseUri() {
-            if (baseUri != null) {
-                return baseUri;
+        public URI getBaseUrl() {
+            if (baseUrl != null) {
+                return baseUrl;
             }
             {
                 // backwards compatibility
                 if (origin == null) {
-                    throw new IllegalStateException("Either baseUri or origin must be set");
+                    throw new IllegalStateException("Either baseUrl or origin must be set");
                 }
                 if (originHasProtocol()) {
                     return URI.create(origin);
@@ -91,8 +94,12 @@ class ScmConfiguration {
             this.type = type;
         }
 
-        public void setAlternativeUris(@Nullable List<URI> alternativeUris) {
-            this.alternativeUris = alternativeUris;
+        public void setAlternativeUrls(@Nullable List<URI> alternativeUrls) {
+            this.alternativeUrls = alternativeUrls;
+        }
+
+        public void setBaseUrl(@Nullable URI baseUrl) {
+            this.baseUrl = baseUrl;
         }
     }
 

--- a/src/main/java/io/moderne/organizations/ScmConfiguration.java
+++ b/src/main/java/io/moderne/organizations/ScmConfiguration.java
@@ -31,7 +31,7 @@ class ScmConfiguration {
     }
 
     static class ScmRepository {
-        private Service gitRemoteService;
+        private Service type;
         private URI baseUrl;
 
         @Nullable
@@ -53,12 +53,12 @@ class ScmConfiguration {
             this.baseUrl = baseUrl;
         }
 
-        public Service getGitRemoteService() {
-            return gitRemoteService;
+        public Service getType() {
+            return type;
         }
 
-        public void setGitRemoteService(@Nullable Service gitRemoteService) {
-            this.gitRemoteService = gitRemoteService;
+        public void setType(@Nullable Service type) {
+            this.type = type;
         }
     }
 }

--- a/src/main/java/io/moderne/organizations/ScmConfiguration.java
+++ b/src/main/java/io/moderne/organizations/ScmConfiguration.java
@@ -1,44 +1,20 @@
 package io.moderne.organizations;
 
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.GitRemote;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import java.util.ArrayList;
+import java.net.URI;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 @ConfigurationProperties(prefix = "moderne.scm")
-public class ScmConfiguration {
-    private List<ScmRepository> repositories;
+class ScmConfiguration {
     private boolean allowMissingScmOrigins;
-
-    public static class ScmRepository {
-        String origin;
-        Type type;
-
-        public String getOrigin() {
-            return origin;
-        }
-
-        public void setOrigin(String origin) {
-            this.origin = origin;
-        }
-
-        public Type getType() {
-            return type;
-        }
-
-        public void setType(Type type) {
-            this.type = type;
-        }
-
-        public enum Type {
-            GITHUB, BITBUCKET_CLOUD, GITLAB, BITBUCKET, AZURE_DEVOPS
-        }
-    }
+    private List<ScmRepository> repositories;
 
     public List<ScmRepository> getRepositories() {
-        if (repositories == null) {
-            repositories = new ArrayList<>();
-        }
         return repositories;
     }
 
@@ -52,6 +28,72 @@ public class ScmConfiguration {
 
     public void setAllowMissingScmOrigins(boolean allowMissingScmOrigins) {
         this.allowMissingScmOrigins = allowMissingScmOrigins;
+    }
+
+    static class ScmRepository {
+        @Deprecated
+        @Nullable
+        private String origin;
+
+        private GitRemote.Service type;
+
+        @Nullable
+        private URI baseUri;
+
+        @Nullable
+        private List<URI> alternativeUris;
+
+        public List<URI> getAlternativeUris() {
+            if (baseUri != null) {
+                return Objects.requireNonNullElse(alternativeUris, Collections.emptyList());
+            }
+            {
+                // backwards compatibility
+                if (alternativeUris != null) {
+                    throw new IllegalStateException("Using alternativeUris without baseUri is not supported");
+                }
+                if (originHasProtocol()) {
+                    return Collections.emptyList();
+                }
+                return Collections.singletonList(URI.create("ssh://" + origin));
+            }
+        }
+
+        public URI getBaseUri() {
+            if (baseUri != null) {
+                return baseUri;
+            }
+            {
+                // backwards compatibility
+                if (origin == null) {
+                    throw new IllegalStateException("Either baseUri or origin must be set");
+                }
+                if (originHasProtocol()) {
+                    return URI.create(origin);
+                }
+                return URI.create("https://" + origin);
+            }
+        }
+
+        private boolean originHasProtocol() {
+            return origin != null && (origin.startsWith("ssh://") || origin.startsWith("https:/") || origin.startsWith("http://"));
+        }
+
+        public void setOrigin(@Nullable String origin) {
+            this.origin = origin;
+        }
+
+        public GitRemote.Service getType() {
+            return type;
+        }
+
+        public void setType(GitRemote.Service type) {
+            this.type = type;
+        }
+
+        public void setAlternativeUris(@Nullable List<URI> alternativeUris) {
+            this.alternativeUris = alternativeUris;
+        }
     }
 
 

--- a/src/main/java/io/moderne/organizations/ScmConfiguration.java
+++ b/src/main/java/io/moderne/organizations/ScmConfiguration.java
@@ -31,59 +31,18 @@ class ScmConfiguration {
     }
 
     static class ScmRepository {
-
-        @Deprecated // Use baseUrl instead
-        @Nullable
-        private String origin;
-
-        @Deprecated // Use gitRemoteService in stead
-        @Nullable
-        Type type;
-
-        @Nullable
         private Service gitRemoteService;
-
-        @Nullable
         private URI baseUrl;
 
         @Nullable
         private List<URI> alternativeUrls;
 
         public List<URI> getAlternativeUrls() {
-            if (baseUrl != null) {
-                return Objects.requireNonNullElse(alternativeUrls, Collections.emptyList());
-            }
-            // backwards compatibility
-            if (alternativeUrls != null) {
-                throw new IllegalStateException("Using alternativeUrls without baseUrl is not supported");
-            }
-            if (originHasProtocol()) {
-                return Collections.emptyList();
-            }
-            return List.of(URI.create("ssh://" + origin));
+            return Objects.requireNonNullElse(alternativeUrls, Collections.emptyList());
         }
 
         public URI getBaseUrl() {
-            if (baseUrl != null) {
-                return baseUrl;
-            }
-            // backwards compatibility
-            if (origin == null) {
-                throw new IllegalStateException("Either baseUrl or origin must be set");
-            }
-            if (originHasProtocol()) {
-                return URI.create(origin);
-            }
-            return URI.create("https://" + origin);
-
-        }
-
-        private boolean originHasProtocol() {
-            return origin != null && (origin.startsWith("ssh://") || origin.startsWith("https:/") || origin.startsWith("http://"));
-        }
-
-        public void setOrigin(@Nullable String origin) {
-            this.origin = origin;
+            return baseUrl;
         }
 
         public void setAlternativeUrls(@Nullable List<URI> alternativeUrls) {
@@ -94,28 +53,7 @@ class ScmConfiguration {
             this.baseUrl = baseUrl;
         }
 
-        public @Nullable String getOrigin() {
-            return origin;
-        }
-
-        public @Nullable Type getType() {
-            return type;
-        }
-
-        public void setType(@Nullable Type type) {
-            this.type = type;
-        }
-
         public Service getGitRemoteService() {
-            if (gitRemoteService == null && type != null) {
-                return switch (type) {
-                    case GITHUB -> Service.GitHub;
-                    case BITBUCKET_CLOUD -> Service.BitbucketCloud;
-                    case GITLAB -> Service.GitLab;
-                    case BITBUCKET -> Service.Bitbucket;
-                    case AZURE_DEVOPS -> Service.AzureDevOps;
-                };
-            }
             return gitRemoteService;
         }
 
@@ -123,9 +61,4 @@ class ScmConfiguration {
             this.gitRemoteService = gitRemoteService;
         }
     }
-
-    enum Type {
-        GITHUB, BITBUCKET_CLOUD, GITLAB, BITBUCKET, AZURE_DEVOPS
-    }
-
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,9 +5,9 @@ moderne:
   scm:
     allowMissingScmOrigins: true
     repositories:
-      - origin: https://bitbucket.example.com/stash
+      - baseUrl: https://bitbucket.example.com/stash
         type: Bitbucket
-        alternative-uris:
+        alternativeUrls:
           - http://bitbucket.example.com:8080/stash
           - ssh://bitbucket.example.com/stash
           - ssh://bitbucket.example.com:7999/stash

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,13 +5,9 @@ moderne:
   scm:
     allowMissingScmOrigins: true
     repositories:
-      - origin: github.com
-        type: GITHUB
-      - origin: bitbucket.org
-        type: BITBUCKET_CLOUD
-      - origin: gitlab.com
-        type: GITLAB
       - origin: https://bitbucket.example.com/stash
-        type: BITBUCKET
-      - origin: dev.azure.com
-        type: AZURE_DEVOPS
+        type: Bitbucket
+        alternative-uris:
+          - http://bitbucket.example.com:8080/stash
+          - ssh://bitbucket.example.com/stash
+          - ssh://bitbucket.example.com:7999/stash

--- a/src/main/resources/repos.csv
+++ b/src/main/resources/repos.csv
@@ -3,6 +3,7 @@ https://github.com/openrewrite/rewrite-recipe-bom,main,,Default,ALL
 https://github.com/openrewrite/rewrite-recommendations,main,,Default,ALL
 https://github.com/Netflix/eureka,master,,Default,ALL
 https://github.com/WebGoat/WebGoat,main,,Default,ALL
+https://github.com/openrewrite/rewrite,main,OpenRewrite,Open source,ALL
 https://github.com/openrewrite/rewrite-cucumber-jvm,main,OpenRewrite,Open source,ALL
 https://github.com/openrewrite/rewrite-hibernate,main,OpenRewrite,Open source,ALL
 https://github.com/openrewrite/rewrite-javascript,main,OpenRewrite,Open source,ALL


### PR DESCRIPTION
To use the new system that will match different protocols/ports to the same origin you need to update the configuration to something like this:

```yaml
moderne:
  scm:
    repositories:
      - baseUri: https://bitbucket.example.com/stash
        type: Bitbucket
        alternativeUris:
          - http://bitbucket.example.com:8080/stash
          - ssh://bitbucket.example.com/stash
          - ssh://bitbucket.example.com:7999/stash
```

- [x] requires v8.34.0 OpenRewrite release
