### PR TITLE
refactor: Migrate to JSpecify

### DIFF
--- a/src/main/java/io/moderne/organizations/DevCenterDataFetcher.java
+++ b/src/main/java/io/moderne/organizations/DevCenterDataFetcher.java
@@ -6,7 +6,7 @@ import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsData;
 import graphql.schema.DataFetchingEnvironment;
 import io.moderne.organizations.types.*;
-import org.openrewrite.internal.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/src/main/java/io/moderne/organizations/ModerneConfiguration.java
+++ b/src/main/java/io/moderne/organizations/ModerneConfiguration.java
@@ -1,6 +1,6 @@
 package io.moderne.organizations;
 
-import org.openrewrite.internal.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.nio.file.Path;

--- a/src/main/java/io/moderne/organizations/OrganizationDataFetcher.java
+++ b/src/main/java/io/moderne/organizations/OrganizationDataFetcher.java
@@ -8,7 +8,7 @@ import graphql.relay.Connection;
 import graphql.relay.SimpleListConnection;
 import graphql.schema.DataFetchingEnvironment;
 import io.moderne.organizations.types.*;
-import org.openrewrite.internal.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/src/main/java/io/moderne/organizations/OrganizationRepositories.java
+++ b/src/main/java/io/moderne/organizations/OrganizationRepositories.java
@@ -2,7 +2,7 @@ package io.moderne.organizations;
 
 import io.moderne.organizations.types.CommitOption;
 import io.moderne.organizations.types.RepositoryInput;
-import org.openrewrite.internal.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Set;

--- a/src/main/java/io/moderne/organizations/OrganizationStructureService.java
+++ b/src/main/java/io/moderne/organizations/OrganizationStructureService.java
@@ -2,7 +2,7 @@ package io.moderne.organizations;
 
 import io.moderne.organizations.types.CommitOption;
 import io.moderne.organizations.types.RepositoryInput;
-import org.openrewrite.internal.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.jspecify.MigrateFromOpenRewriteAnnotations?organizationId=TW9kZXJuZQ%3D%3D