### PR TITLE
Only return the root of the subtree users have access to

### DIFF
--- a/src/main/java/io/moderne/organizations/OrganizationStructureService.java
+++ b/src/main/java/io/moderne/organizations/OrganizationStructureService.java
@@ -37,7 +37,7 @@ public class OrganizationStructureService {
         this.reposCsvPath = moderneConfiguration.getReposCsvPath();
     }
 
-    public Map<String, OrganizationRepositories> readOrganizationStructure() {
+    OrganizationTree readOrganizationStructure() {
         LinkedHashMap<String, OrganizationRepositories> organizations = new LinkedHashMap<>();
         Set<RepositoryInput> allRepositories = new LinkedHashSet<>();
 
@@ -111,7 +111,7 @@ public class OrganizationStructureService {
         }
         organizations.put("ALL", new OrganizationRepositories("ALL", "ALL", allRepositories, List.of(CommitOption.values()), null));
         logStructure(organizations);
-        return organizations;
+        return new OrganizationTree(organizations.values());
     }
 
     private static Map<String, String> readIdToNameMapping() {

--- a/src/main/java/io/moderne/organizations/OrganizationTree.java
+++ b/src/main/java/io/moderne/organizations/OrganizationTree.java
@@ -1,0 +1,136 @@
+package io.moderne.organizations;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.*;
+
+class OrganizationTree {
+    private final Map<String, Node> nodeMap = new LinkedHashMap<>();
+    private final List<OrganizationRepositories> roots = new ArrayList<>();
+
+    public OrganizationTree(Collection<OrganizationRepositories> organizations) {
+        for (OrganizationRepositories org : organizations) {
+            nodeMap.put(org.id(), new Node(org));
+        }
+
+        for (Node node : nodeMap.values()) {
+            if (node.getParentId() != null) {
+                Node parent = nodeMap.get(node.getParentId());
+                parent.children.add(node);
+                precomputeAncestors(node, parent);
+            } else {
+                roots.add(node.organization);
+            }
+        }
+    }
+
+    public Collection<OrganizationRepositories> all() {
+        return asMap().values();
+    }
+
+    public @Nullable OrganizationRepositories findOrganization(String id) {
+        return nodeMap.containsKey(id) ? nodeMap.get(id).organization : null;
+    }
+
+    public int size() {
+        return nodeMap.size();
+    }
+
+    public boolean isEmpty() {
+        return nodeMap.isEmpty();
+    }
+
+    public Collection<OrganizationRepositories> roots() {
+        return roots;
+    }
+
+    /**
+     * Returns the subtree of the given organization excluding itself
+     *
+     * @param orgId the id of the organization
+     * @return the children
+     */
+    public Collection<OrganizationRepositories> findChildren(String orgId) {
+        List<OrganizationRepositories> subTree = findSubtree(orgId);
+        if (!subTree.isEmpty()) {
+            subTree.remove(0);
+        }
+        return subTree;
+    }
+
+    /**
+     * Returns the subtree of the given organization including itself
+     *
+     * @param orgId the id of the organization
+     * @return the subtree
+     */
+    public List<OrganizationRepositories> findSubtree(String orgId) {
+        Node node = nodeMap.get(orgId);
+        if (node == null) {
+            return List.of();
+        }
+        List<OrganizationRepositories> subtree = new ArrayList<>();
+        collectSubtree(node, subtree);
+        return subtree;
+    }
+
+    private void collectSubtree(Node node, List<OrganizationRepositories> subtree) {
+        subtree.add(node.organization);
+        for (Node child : node.children) {
+            collectSubtree(child, subtree);
+        }
+    }
+
+    private void precomputeAncestors(Node node, Node parent) {
+        node.ancestors.addAll(parent.ancestors);
+        node.ancestors.add(parent.organization);
+    }
+
+    public Map<String, OrganizationRepositories> asMap() {
+        // Instead of recomputing the map we extract values on the fly in a view of the original NodeMap
+        return new AbstractMap<>() {
+            @Override
+            public Set<Entry<String, OrganizationRepositories>> entrySet() {
+                return new AbstractSet<>() {
+                    @Override
+                    public Iterator<Entry<String, OrganizationRepositories>> iterator() {
+                        return new Iterator<>() {
+                            private final Iterator<Entry<String, Node>> originalIterator = nodeMap.entrySet().iterator();
+
+                            @Override
+                            public boolean hasNext() {
+                                return originalIterator.hasNext();
+                            }
+
+                            @Override
+                            public Entry<String, OrganizationRepositories> next() {
+                                Entry<String, Node> originalEntry = originalIterator.next();
+                                return new SimpleEntry<>(originalEntry.getKey(), originalEntry.getValue().organization);
+                            }
+                        };
+                    }
+
+                    @Override
+                    public int size() {
+                        return nodeMap.size();
+                    }
+                };
+            }
+        };
+    }
+
+    private static class Node {
+        OrganizationRepositories organization;
+        List<Node> children = new ArrayList<>();
+        List<OrganizationRepositories> ancestors = new ArrayList<>();
+
+        Node(OrganizationRepositories organization) {
+            this.organization = organization;
+        }
+
+        public @Nullable String getParentId() {
+            return organization.parent();
+        }
+    }
+
+}

--- a/src/test/java/io/moderne/organizations/OrganizationStructureServiceTest.java
+++ b/src/test/java/io/moderne/organizations/OrganizationStructureServiceTest.java
@@ -24,7 +24,7 @@ class OrganizationStructureServiceTest {
 
     @Test
     void removeScmFromBitbucketCloneUrl() {
-        OrganizationRepositories organizationRepositories = structureService.readOrganizationStructure().get("Bitbucket");
+        OrganizationRepositories organizationRepositories = structureService.readOrganizationStructure().findOrganization("Bitbucket");
         assertThat(organizationRepositories.repositories())
                 .extracting(RepositoryInput::getOrigin)
                 .containsExactly("bitbucket.example.com/stash");


### PR DESCRIPTION
Instead of returning the full list of organizations a user has access too we only need the root of the subtree the user has access too. This will reduce the network call to a bare minimal which is useful when there are large numbers of organizations.
