### PR TITLE
Add pagination to organizations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,7 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 
-    implementation("com.netflix.graphql.dgs:graphql-dgs-webflux-starter")
+    implementation("com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter")
     implementation("com.netflix.graphql.dgs:graphql-dgs-spring-boot-micrometer")
 
     implementation("io.micrometer:micrometer-registry-prometheus:latest.release")

--- a/src/main/java/io/moderne/organizations/OrganizationDataFetcher.java
+++ b/src/main/java/io/moderne/organizations/OrganizationDataFetcher.java
@@ -11,7 +11,6 @@ import io.moderne.organizations.types.*;
 import org.openrewrite.internal.lang.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -37,13 +36,12 @@ public class OrganizationDataFetcher {
     @DgsQuery
     Mono<Connection<Organization>> organizationsPages(DataFetchingEnvironment dfe) {
         return Mono.fromCallable(() -> {
-                    List<Organization> allOrganizations = organizations.all()
-                            .stream()
-                            .map(this::mapOrganization)
-                            .toList();
-                    return new SimpleListConnection<>(allOrganizations).get(dfe);
-                })
-                .subscribeOn(Schedulers.boundedElastic());
+            List<Organization> allOrganizations = organizations.all()
+                    .stream()
+                    .map(this::mapOrganization)
+                    .toList();
+            return new SimpleListConnection<>(allOrganizations).get(dfe);
+        });
     }
 
     @DgsQuery

--- a/src/main/java/io/moderne/organizations/OrganizationDataFetcher.java
+++ b/src/main/java/io/moderne/organizations/OrganizationDataFetcher.java
@@ -32,7 +32,6 @@ public class OrganizationDataFetcher {
                 .map(this::mapOrganization);
     }
 
-
     @DgsQuery
     Mono<Connection<Organization>> organizationsPages(DataFetchingEnvironment dfe) {
         return Mono.fromCallable(() -> {

--- a/src/main/resources/schema/moderne-organizations.graphqls
+++ b/src/main/resources/schema/moderne-organizations.graphqls
@@ -5,12 +5,37 @@ type Query {
     allOrganizations: [Organization!]!
 
     """
+    The paginated list of all possible organizations
+    """
+    organizationsPages(
+        after: String
+        first: Int = 100
+        before: String
+        last: Int
+    ): OrganizationConnection!
+
+    """
     The list of organizations that a user belongs to. If it is possible to
     determine the organizations that a user belonged to at a given time, use the `at`
     parameter. The "default" organization that is selected for a user is the first organization
     returned.
     """
     userOrganizations(user: User!, at: DateTime): [Organization!]!
+
+    """
+    The paginated list of organizations that a user belongs to. If it is possible to
+    determine the organizations that a user belonged to at a given time, use the `at`
+    parameter. The "default" organization that is selected for a user is the first organization
+    returned.
+    """
+    userOrganizationsPages(
+        user: User!
+        at: DateTime
+        after: String
+        first: Int = 100
+        before: String
+        last: Int
+    ): OrganizationConnection!
 
     """
     A single organization by id.
@@ -39,6 +64,17 @@ type Organization {
         first: Int = 100,
         before: String,
         last: Int): RepositoryConnection!
+}
+
+type OrganizationConnection {
+    edges: [OrganizationEdge]
+    pageInfo: PageInfo
+    count: Int
+}
+
+type OrganizationEdge {
+    node: Organization
+    cursor: String
 }
 
 type RepositoryConnection {


### PR DESCRIPTION
With large numbers of organizations the graphQL responses can get really big. By paginating the organizations we keep the payloads small.
