### PR TITLE
Fix loading of overridden CSV path and create test to confirm this works

### DIFF
--- a/src/main/java/io/moderne/organizations/OrganizationStructureService.java
+++ b/src/main/java/io/moderne/organizations/OrganizationStructureService.java
@@ -50,10 +50,10 @@ public class OrganizationStructureService {
 
         InputStream inputStream;
         try {
-            if (reposCsvPath == null) {
-                inputStream = new ClassPathResource(DEFAULT_REPOS_CSV).getInputStream();
-            } else {
+            if (reposCsvPath != null && reposCsvPath.toFile().exists()) {
                 inputStream = new FileInputStream(reposCsvPath.toFile());
+            } else {
+                inputStream = new ClassPathResource(reposCsvPath != null ? reposCsvPath.toString() : DEFAULT_REPOS_CSV).getInputStream();
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/src/test/java/io/moderne/organizations/OrganizationStructureServiceCustomTest.java
+++ b/src/test/java/io/moderne/organizations/OrganizationStructureServiceCustomTest.java
@@ -1,0 +1,35 @@
+package io.moderne.organizations;
+
+import io.moderne.organizations.types.RepositoryInput;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@AutoConfigureObservability
+@SpringBootTest(properties = {
+        "spring.config.location=classpath:/application-test.yaml"
+})
+class OrganizationStructureServiceCustomTest {
+
+    @Autowired
+    OrganizationStructureService structureService;
+
+    @Test
+    void canReadAllOrganizations() {
+        structureService.readOrganizationStructure();
+    }
+
+    @Test
+    void removeScmFromBitbucketCloneUrl() {
+        OrganizationRepositories organizationRepositories = structureService.readOrganizationStructure().findOrganization("Bitbucket TEST ORG");
+        assertThat(organizationRepositories.repositories())
+                .extracting(RepositoryInput::getOrigin)
+                .containsExactly("bitbucket.example.com/stash");
+        assertThat(organizationRepositories.repositories())
+                .extracting(RepositoryInput::getPath)
+                .containsExactly("openrewrite/rewrite");
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,14 @@
+management.endpoints.web.exposure.include: prometheus,health
+management.endpoint.prometheus.enabled: true
+management.endpoint.health.enabled: true
+moderne:
+  reposCsvPath: repos-test.csv
+  scm:
+    allowMissingScmOrigins: true
+    repositories:
+      - baseUrl: https://bitbucket.example.com/stash
+        type: Bitbucket
+        alternativeUrls:
+          - http://bitbucket.example.com:8080/stash
+          - ssh://bitbucket.example.com/stash
+          - ssh://bitbucket.example.com:7999/stash

--- a/src/test/resources/repos-test.csv
+++ b/src/test/resources/repos-test.csv
@@ -1,0 +1,54 @@
+cloneUrl,branch,org1,org2,org3,org4
+https://github.com/openrewrite/rewrite-recipe-bom,main,Default,ALL
+https://github.com/openrewrite/rewrite-recommendations,main,Default,ALL
+https://github.com/Netflix/eureka,master,Default,ALL
+https://github.com/WebGoat/WebGoat,main,Default,ALL
+https://github.com/openrewrite/rewrite,main,OpenRewrite,Open source,ALL
+https://github.com/openrewrite/rewrite-cucumber-jvm,main,OpenRewrite,Open source,ALL
+https://github.com/openrewrite/rewrite-hibernate,main,OpenRewrite,Open source,ALL
+https://github.com/openrewrite/rewrite-javascript,main,OpenRewrite,Open source,ALL
+https://github.com/openrewrite/rewrite-launchdarkly,main,OpenRewrite,Open source,ALL
+https://github.com/openrewrite/rewrite-liberty,main,OpenRewrite,Open source,ALL
+https://github.com/openrewrite/rewrite-maven-plugin,main,OpenRewrite,Open source,ALL
+https://github.com/openrewrite/rewrite-micrometer,main,OpenRewrite,Open source,ALL
+https://github.com/openrewrite/rewrite-micronaut,main,OpenRewrite,Open source,ALL
+https://github.com/openrewrite/rewrite-okhttp,main,OpenRewrite,Open source,ALL
+https://github.com/openrewrite/rewrite-recipe-bom,main,OpenRewrite,Open source,ALL
+https://github.com/openrewrite/rewrite-recommendations,main,OpenRewrite,Open source,ALL
+https://github.com/WebGoat/WebGoat,main,WebGoat,Test,ALL
+https://github.com/WebGoat/WebGoat-Legacy,master,WebGoat,Test,ALL
+https://github.com/WebGoat/WebGoat-Lessons,develop,WebGoat,Test,ALL
+https://github.com/WebGoat/WebWolf,master,WebGoat,Test,ALL
+https://github.com/WebGoat/WebGoat-Archived-Releases,master,WebGoat,Test,ALL
+https://github.com/WebGoat/groovygoat,master,WebGoat,Test,ALL
+https://github.com/Netflix/mantis,master,Netflix,Open source,ALL
+https://github.com/Netflix/eclipse-jifa,main,Netflix,Open source,ALL
+https://github.com/Netflix/dispatch,master,Netflix,Open source,ALL
+https://github.com/Netflix/metacat,master,Netflix,Open source,ALL
+https://github.com/Netflix/spectator-go,main,Netflix,Open source,ALL
+https://github.com/Netflix/metaflow,master,Netflix,Open source,ALL
+https://github.com/Netflix/dgs,main,Netflix,Open source,ALL
+https://github.com/Netflix/dgs-framework,master,Netflix,Open source,ALL
+https://github.com/Netflix/OpenVPCal,main,Netflix,Open source,ALL
+https://github.com/Netflix/bpftop,main,Netflix,Open source,ALL
+https://github.com/Netflix/atlas-docs,main,Netflix,Open source,ALL
+https://github.com/Netflix/dgs-intellij-plugin,main,Netflix,Open source,ALL
+https://github.com/Netflix/lemur,main,Netflix,Open source,ALL
+https://github.com/Netflix/atlas,main,Netflix,Open source,ALL
+https://github.com/Netflix/metaflow-docs,master,Netflix,Open source,ALL
+https://github.com/Netflix/Priam,3.x,Netflix,Open source,ALL
+https://github.com/Netflix/zuul,master,Netflix,Open source,ALL
+https://github.com/Netflix/eureka,master,Netflix,Open source,ALL
+https://github.com/Netflix/genie,master,Netflix,Open source,ALL
+https://github.com/Netflix/metaflow-nflx-extensions,main,Netflix,Open source,ALL
+https://github.com/Netflix/dgs-examples-java,main,Netflix,Open source,ALL
+https://github.com/Netflix/eslint-config-netflix,main,Netflix,Open source,ALL
+https://github.com/Netflix/vectorflow,master,Netflix,Open source,ALL
+https://github.com/Netflix/metaflow-service,master,Netflix,Open source,ALL
+https://github.com/Netflix/metaflow-ui,master,Netflix,Open source,ALL
+https://github.com/Netflix/dgs-codegen,master,Netflix,Open source,ALL
+https://github.com/Netflix/iep,main,Netflix,Open source,ALL
+https://github.com/Netflix/mantis-rxcontrol,master,Netflix,Open source,ALL
+https://github.com/Netflix/vmaf,master,Netflix,Open source,ALL
+https://github.com/Netflix/x-element,main,Netflix,Open source,ALL
+https://bitbucket.example.com/stash/scm/openrewrite/rewrite.git,main,Bitbucket TEST ORG,OpenRewrite,Open source,ALL


### PR DESCRIPTION
Specifying a reposCsvPath did not successfully load it as a classpath resource, only as a file resource. In order to allow both options, both for unit testing as well as locally packaging up the file in the codebase, a small change needs to be made to how the path is read.