### PR TITLE
chore/empty-organizations-hint

### DIFF
--- a/src/main/java/io/moderne/organizations/OrganizationStructureService.java
+++ b/src/main/java/io/moderne/organizations/OrganizationStructureService.java
@@ -79,7 +79,7 @@ public class OrganizationStructureService {
                 if (orgNames.isEmpty()) {
                     throw new IllegalStateException("repos.csv lines should have at least 1 organization");
                 } else if (orgNames.contains("")) {
-                    throw new IllegalStateException("Invalid organization \"\" for %s".formatted(cloneUrl));
+                    throw new IllegalStateException("Invalid organization \"\" for %s. \nCheck your repos.csv for extra commas, e.g. ,,,ALL or lines ending in ,".formatted(cloneUrl));
                 }
 
                 boolean first = true;


### PR DESCRIPTION
A repos.csv that contains multiple commas in the organizations section or trailing commas can result in empty organizations during parsing. Add hint when this occurs so user knows what configuration to check. 