### PR TITLE
Bump Spring Boot versions to latest 3.2.x

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ buildscript {
 }
 
 plugins {
-    id("org.springframework.boot") version "3.2.2"
+    id("org.springframework.boot") version "3.2.10"
     java
     id("nebula.release") version "19.0.10"
     id("nebula.maven-nebula-publish") version "18.2.0"
@@ -62,7 +62,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:latest.release")
     
     implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
-    implementation(platform("org.springframework.cloud:spring-cloud-dependencies:2023.0.0"))
+    implementation(platform("org.springframework.cloud:spring-cloud-dependencies:2023.0.3"))
     implementation(platform("io.netty:netty-bom:4.1.100.Final"))
     implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform:latest.release"))
 


### PR DESCRIPTION
We received Xray reports of a dependency on `micrometer-commons:1.14.0-RC1` via `micrometer-jakarta9:1.12.2`; not backed up up by what we see in: https://repo1.maven.org/maven2/io/micrometer/micrometer-jakarta9/1.12.2/micrometer-jakarta9-1.12.2.pom

Figured bump Spring Boot versions to the latest in 3.2.x anyway to stay ahead of issues. Didn't yet leap to 3.3.x, but could if that's preferred.