### PR TITLE
Handle commit options in GraphQL endpoint codepath and remove devcenter.json endpoint

### DIFF
--- a/src/main/java/io/moderne/organizations/CommitOptions.java
+++ b/src/main/java/io/moderne/organizations/CommitOptions.java
@@ -1,0 +1,34 @@
+package io.moderne.organizations;
+
+import io.moderne.organizations.types.CommitOption;
+
+import java.io.*;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public record CommitOptions(Map<String, List<CommitOption>> commitOptions) {
+
+    public static CommitOptions fromInputStream(InputStream commitOptionsInputStream) {
+        Map<String, List<CommitOption>> configuredCommitOptions = new LinkedHashMap<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(commitOptionsInputStream))) {
+            reader.lines().forEach(line -> {
+                String[] fields = line.split("=");
+                if (fields.length != 2) {
+                    throw new IllegalStateException("Commit options should contain <organization>=<Comma separated list of commit options>");
+                }
+                String organization = fields[0].trim();
+                List<CommitOption> options = Arrays.stream(fields[1].trim().split(",")).map(String::trim).map(CommitOption::valueOf).toList();
+                configuredCommitOptions.put(organization, options);
+            });
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return new CommitOptions(configuredCommitOptions);
+    }
+
+    public List<CommitOption> find(String organization) {
+        return commitOptions().getOrDefault(organization, List.of(CommitOption.values()));
+    }
+}

--- a/src/main/java/io/moderne/organizations/OrganizationController.java
+++ b/src/main/java/io/moderne/organizations/OrganizationController.java
@@ -15,7 +15,6 @@ import java.io.InputStream;
 
 @RestController
 public class OrganizationController {
-    private static final String DEV_CENTER_JSON = "/devcenter.json";
     OrganizationStructureService organizationStructureService;
 
     public OrganizationController(OrganizationStructureService organizationStructureService) {
@@ -27,7 +26,7 @@ public class OrganizationController {
         response.getHeaders().setContentType(MediaType.TEXT_PLAIN);
         response.getHeaders().add("Content-Disposition", "attachment; filename=repos.csv");
 
-        return DataBufferUtils.readInputStream(() -> organizationStructureService.getReposCsvInputStream(), new DefaultDataBufferFactory(), 4096);
+        return DataBufferUtils.readInputStream(() -> organizationStructureService.loadReposCsvInputStream(), new DefaultDataBufferFactory(), 4096);
     }
 
     @GetMapping("/commit-options")
@@ -35,21 +34,13 @@ public class OrganizationController {
         response.getHeaders().setContentType(MediaType.TEXT_PLAIN);
         response.getHeaders().add("Content-Disposition", "attachment; filename=commitOptions.txt");
 
-        return DataBufferUtils.readInputStream(() -> organizationStructureService.getCommitOptionsInputStream(), new DefaultDataBufferFactory(), 4096);
+        return DataBufferUtils.readInputStream(() -> organizationStructureService.loadCommitOptionsInputStream(), new DefaultDataBufferFactory(), 4096);
     }
 
     @GetMapping("/id-mapping")
     Flux<DataBuffer> getIdMapping(ServerHttpResponse response) {
         response.getHeaders().setContentType(MediaType.TEXT_PLAIN);
         response.getHeaders().add("Content-Disposition", "attachment; filename=id-mapping.txt");
-        return DataBufferUtils.readInputStream(OrganizationStructureService::getNameMappingInputStream, new DefaultDataBufferFactory(), 4096);
-    }
-
-    @GetMapping("/devcenter")
-    Flux<DataBuffer> getDevCenter(ServerHttpResponse response) throws IOException {
-        response.getHeaders().setContentType(MediaType.TEXT_PLAIN);
-        response.getHeaders().add("Content-Disposition", "attachment; filename=devcenter.json");
-        InputStream inputStream = new ClassPathResource(DEV_CENTER_JSON).getInputStream();
-        return DataBufferUtils.readInputStream(() -> inputStream, new DefaultDataBufferFactory(), 4096);
+        return DataBufferUtils.readInputStream(OrganizationStructureService::loadNameMappingInputStream, new DefaultDataBufferFactory(), 4096);
     }
 }

--- a/src/main/resources/commitOptions.txt
+++ b/src/main/resources/commitOptions.txt
@@ -1,1 +1,3 @@
 Default=Branch,PullRequest
+OpenRewrite=PullRequest,Branch,Direct
+Open source=Fork,ForkAndPullRequest

--- a/src/test/java/io/moderne/organizations/OrganizationDataFetcherTest.java
+++ b/src/test/java/io/moderne/organizations/OrganizationDataFetcherTest.java
@@ -1,5 +1,6 @@
 package io.moderne.organizations;
 
+import io.moderne.organizations.types.CommitOption;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
@@ -23,34 +24,42 @@ public class OrganizationDataFetcherTest {
                     assertThat(next.getId()).isEqualTo("Default");
                     assertThat(next.getName()).isEqualTo("Default Organization");
                     assertThat(next.getParent().getId()).isEqualTo("ALL");
+                    assertThat(next.getCommitOptions()).containsExactly(CommitOption.Branch,CommitOption.PullRequest);
                 })
                 .assertNext(next -> {
                     assertThat(next.getId()).isEqualTo("ALL");
+                    assertThat(next.getCommitOptions()).containsExactly(CommitOption.values());
                     assertThat(next.getParent()).isNull();
                 })
                 .assertNext(next -> {
                     assertThat(next.getId()).isEqualTo("OpenRewrite");
                     assertThat(next.getParent().getId()).isEqualTo("Open source");
+                    assertThat(next.getCommitOptions()).containsExactly(CommitOption.PullRequest,CommitOption.Branch,CommitOption.Direct);
                 })
                 .assertNext(next -> {
                     assertThat(next.getId()).isEqualTo("Open source");
                     assertThat(next.getParent().getId()).isEqualTo("ALL");
+                    assertThat(next.getCommitOptions()).containsExactly(CommitOption.Fork,CommitOption.ForkAndPullRequest);
                 })
                 .assertNext(next -> {
                     assertThat(next.getId()).isEqualTo("WebGoat");
                     assertThat(next.getParent().getId()).isEqualTo("Test");
+                    assertThat(next.getCommitOptions()).containsExactly(CommitOption.values());
                 })
                 .assertNext(next -> {
                     assertThat(next.getId()).isEqualTo("Test");
                     assertThat(next.getParent().getId()).isEqualTo("ALL");
+                    assertThat(next.getCommitOptions()).containsExactly(CommitOption.values());
                 })
                 .assertNext(next -> {
                     assertThat(next.getId()).isEqualTo("Netflix");
                     assertThat(next.getParent().getId()).isEqualTo("Open source");
+                    assertThat(next.getCommitOptions()).containsExactly(CommitOption.values());
                 })
                 .assertNext(next -> {
                     assertThat(next.getId()).isEqualTo("Bitbucket");
                     assertThat(next.getParent().getId()).isEqualTo("OpenRewrite");
+                    assertThat(next.getCommitOptions()).containsExactly(CommitOption.values());
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
We are still exploring how to best expose devcenter configuration. For now the GraphQL queries will still be used.
