### PR TITLE
Upgrade to Spring Boot 3.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ buildscript {
 }
 
 plugins {
-    id("org.springframework.boot") version "3.5.7"
+    id("org.springframework.boot") version "3.5.12"
     java
     id("nebula.release") version "19.0.10"
     id("nebula.maven-nebula-publish") version "18.2.0"


### PR DESCRIPTION
Bump`org.springframework.boot` 3.5.7 -> 3.5.12

- Related: https://github.com/moderneinc/dependency-vulnerability-reports/issues/1032