### PR TITLE
Upgrade netty to 4.1.132 (CVE-2026-33871, CVE-2026-33870)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
 
     implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
     implementation(platform("org.springframework.cloud:spring-cloud-dependencies:2025.0.0"))
-    implementation(platform("io.netty:netty-bom:4.1.127.Final"))
+    implementation(platform("io.netty:netty-bom:4.1.+"))
 
     implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform:latest.release"))
 


### PR DESCRIPTION
## What

Upgrade `io.netty:netty-bom` from 4.1.127.Final to 4.1.132.Final


## Why

To remediate:
- CVE-2026-33871
- CVE-2026-33870

as called out by https://github.com/moderneinc/dependency-vulnerability-reports/issues/1043