### PR TITLE
Pin DGS GraphQL to 10.5.+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,8 @@ dependencies {
     implementation(platform("org.springframework.cloud:spring-cloud-dependencies:2025.0.0"))
     implementation(platform("io.netty:netty-bom:4.1.+"))
 
-    implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform:latest.release"))
+    // Pinned to the 10.x line to stay on Spring Boot 3.5.x; DGS 11.x targets Spring Boot 4.x.
+    implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform:10.5.+"))
 
     implementation("org.openrewrite:rewrite-core:latest.release")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")


### PR DESCRIPTION
**What**:
Pin the `com.netflix.graphql.dgs:graphql-dgs-platform` to 10.5.+.

**Why**:
- This is the newest version/branch which does **not** bring Spring Boot 4.0. And currently the tests crash with:
```
OrganizationDataFetcherTest > organizationsStructure() FAILED
    java.lang.IllegalStateException at DefaultCacheAwareContextLoaderDelegate.java:180
        Caused by: java.lang.IllegalStateException at SpringApplication.java:836
            Caused by: java.lang.NoClassDefFoundError at SpringBootContextLoader.java:264
                Caused by: java.lang.ClassNotFoundException at BuiltinClassLoader.java:641
```
as we have Spring Boot 3.5 vs 4.x conflict.

The direct trigger for me looking into it was that the newer versions of the DGS dependency bring vulnerable (shadowed) Jackson in 3.x, branch. I was surprised we even bring Jackson 3.