### PR TITLE
fix: upgrade netty-bom to 4.2.+ (CVE-2026-41417, CVE-2026-42577..CVE-2026-42585)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
 
     implementation(platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
     implementation(platform("org.springframework.cloud:spring-cloud-dependencies:2025.0.0"))
-    implementation(platform("io.netty:netty-bom:4.1.+"))
+    implementation(platform("io.netty:netty-bom:4.2.+"))
 
     // Pinned to the 10.x line to stay on Spring Boot 3.5.x; DGS 11.x targets Spring Boot 4.x.
     implementation(platform("com.netflix.graphql.dgs:graphql-dgs-platform:10.5.+"))


### PR DESCRIPTION
## Summary

- Bumps the Netty BOM pin from `4.1.+` to `4.2.+` to clear CRITICAL vulnerabilities flagged in moderneinc/dependency-vulnerability-reports#1081 (2026-05-28 Moderne dependency vulnerability report).

All `io.netty:*` artifacts now resolve to **4.2.14.Final** (verified via `./gradlew dependencies`), which patches:

- CVE-2026-41417
- CVE-2026-42577
- CVE-2026-42578
- CVE-2026-42579
- CVE-2026-42580
- CVE-2026-42581
- CVE-2026-42582 (patched in 4.2.13.Final)
- CVE-2026-42583
- CVE-2026-42584
- CVE-2026-42585

These affect every Netty artifact pulled in transitively via Spring Boot's `spring-boot-starter-webflux` → `reactor-netty` chain: `netty-buffer`, `netty-codec`, `netty-codec-dns`, `netty-codec-http`, `netty-codec-http2`, `netty-codec-socks`, `netty-common`, `netty-handler`, `netty-handler-proxy`, `netty-resolver`, `netty-resolver-dns`, `netty-resolver-dns-classes-macos`, `netty-resolver-dns-native-macos`, `netty-transport`, `netty-transport-classes-epoll`, `netty-transport-native-epoll`, `netty-transport-native-unix-common`.

This service is distributed to customer infrastructure, where customer scanners (Wiz, BlackDuck, Snyk) hard-block builds on version numbers — so we're upgrading rather than suppressing.

- Follows the same pattern as the earlier #131 (`4.1.127.Final` → `4.1.+`), now moving to the 4.2.x line.

## Test plan

- [x] `./gradlew dependencies --configuration runtimeClasspath` — all `io.netty:*` resolve to 4.2.14.Final
- [x] `./gradlew build` — passes
- [x] `./gradlew test --rerun-tasks` — passes
- [ ] CI green