### PR TITLE
Suppress false-positive netty CVE-2026-42582 (4.1.x not in affected range)

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -42,4 +42,21 @@
         <cve>CVE-2026-40894</cve>
         <cve>CVE-2026-41078</cve>
     </suppress>
+
+    <suppress until="2026-07-03Z">
+        <notes><![CDATA[
+        file name: netty-*-4.1.135.Final.jar (all io.netty modules)
+        severity: HIGH
+        reason: FALSE POSITIVE (version not in affected range). CVE-2026-42582 (GHSA-2c5c-chwr-9hqw)
+        is an HTTP/3 QPACK decoder unbounded-allocation flaw that affects netty 4.2.0.Final through
+        4.2.12.Final, fixed in 4.2.13.Final. This project uses netty 4.1.135.Final (managed
+        transitively by the Spring Boot 3.5.14 BOM via reactor-netty 1.2.17), which is on the 4.1.x
+        branch and predates / does not contain the vulnerable HTTP/3 QPACK code. netty-codec-http3
+        is not present on the classpath at all. No upgrade needed: 4.1.x is not affected, and the
+        fix branch (4.2.x) is not managed by Spring Boot 3.5.x — it will arrive via a future Spring
+        Boot bump. Flagged in moderneinc/dependency-vulnerability-reports#1084.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty-.*@.*$</packageUrl>
+        <cve>CVE-2026-42582</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Summary

Suppresses HIGH **CVE-2026-42582** (GHSA-2c5c-chwr-9hqw), flagged across all 16 `io.netty:netty-*` modules at `4.1.135.Final`.

This is a **false positive**: the CVE is an HTTP/3 QPACK decoder unbounded-allocation flaw that affects **netty 4.2.0.Final–4.2.12.Final** and is **fixed in 4.2.13.Final**. This project ships netty **4.1.135.Final** (managed transitively by the Spring Boot 3.5.14 BOM via reactor-netty 1.2.17) — a different branch that predates and does not contain the vulnerable HTTP/3 QPACK code. `netty-codec-http3` (where the QPACK decoder lives) is not on the classpath at all.

No upgrade is appropriate: 4.1.x is not affected, and the fix branch (4.2.x) is not managed by Spring Boot 3.5.x. The suppression is **time-boxed to 2026-07-03** so it gets re-evaluated after a future Spring Boot bump moves netty to 4.2.13+.

## Test plan
- `xmllint --noout suppressions.xml` passes.

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1084